### PR TITLE
feat: Add nginx load balancer for Grafana replication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
       KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
     depends_on:
-          kafka:
+      kafka:
         condition: service_healthy
     restart: unless-stopped
     networks:
@@ -105,23 +105,66 @@ services:
       - app-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8086/ping"]
-            interval: 10s
+      interval: 10s
       timeout: 5s
       retries: 5
 
-  grafana:
+  grafana-1:
     image: grafana/grafana:latest
-    container_name: grafana
-    ports:
-      - "3000:3000"
+    container_name: grafana-1
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
     volumes:
-      - grafana-data:/var/lib/grafana
+      - grafana-data-1:/var/lib/grafana
     depends_on:
       influxdb:
         condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  grafana-2:
+    image: grafana/grafana:latest
+    container_name: grafana-2
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana-data-2:/var/lib/grafana
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  grafana-3:
+    image: grafana/grafana:latest
+    container_name: grafana-3
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana-data-3:/var/lib/grafana
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  nginx:
+    image: nginx:alpine
+    container_name: nginx-lb
+    ports:
+      - "3000:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - grafana-1
+      - grafana-2
+      - grafana-3
     restart: unless-stopped
     networks:
       - app-network
@@ -133,7 +176,6 @@ networks:
 volumes:
   sniffer-data:
   influxdb-data:
-  grafana-data:
-
-
-
+  grafana-data-1:
+  grafana-data-2:
+  grafana-data-3:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,31 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream grafana_backend {
+        server grafana-1:3000;
+        server grafana-2:3000;
+        server grafana-3:3000;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            proxy_pass http://grafana_backend;
+            
+            # Исправляем заголовки для правильных редиректов
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            
+            # Отключаем буферизацию для WebSocket
+            proxy_buffering off;
+            proxy_redirect off;
+        }
+    }
+}


### PR DESCRIPTION
- Implement round-robin load balancing with nginx
- Add 3 Grafana instances behind single entry point
- Enable automatic failover for high availability
- Configure unified access via localhost:3000